### PR TITLE
Activate pnpm from node's corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:23.5.0-alpine
 
 RUN mkdir -p /drone/volume \
-  && touch /drone/volume/npmrc \
-  && ln -s /drone/volume/npmrc /root/.npmrc
+    && touch /drone/volume/npmrc \
+    && ln -s /drone/volume/npmrc /root/.npmrc \
+    && npm install -g pnpm


### PR DESCRIPTION
Activated the pre-packaged (corepack) pnpm

* pnpm gets delivered with node through corepack
* pnpm offers an efficient way of managing a monorepo.
 
the benefits for activating it in this image can be seen as a viable extension to the offered image in case someone wants to use it without introducing an additional layer and maintenance effort